### PR TITLE
docs(README): add instructions to run ng-de.org locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ Website for the conference
 
 ## Photos
 Background Image by Daniel Brosch on Unsplash
+
+## Development
+
+Once you have forked this repository and downloaded it to you machine run the following commands to start [ng-de.org](https://ng-de.org/) locally.
+
+```bash
+# install dependencies
+bundle
+
+# start the web page at http://localhost:4000
+bundle exec jekyll serve
+```


### PR DESCRIPTION
## What is this about?

- Add instructions for developers to run ng-de.org locally

## Benefit

I thought that it could be useful to add some words how this project can be run locally.
If more developers join the team to enhance [ng-de.org](https://ng-de.org)'s webpage it is easier for them to get started.